### PR TITLE
Update to use Hangfire.Logging

### DIFF
--- a/tutorials/send-email.rst
+++ b/tutorials/send-email.rst
@@ -242,14 +242,14 @@ You can log cases when the maximum number of retry attempts has been exceeded. T
 
     public class LogFailureAttribute : JobFilterAttribute, IApplyStateFilter
     {
-        private static readonly ILog Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
         public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
             var failedState = context.NewState as FailedState;
             if (failedState != null)
             {
-                Logger.Error(
+                Logger.ErrorException(
                     String.Format("Background job #{0} was failed with an exception.", context.JobId), 
                     failedState.Exception);
             }


### PR DESCRIPTION
It seems like you would always want to use the Hangfire.Logging classes as opposed to a specific logger (such as NLog).  This changes the example to use the Hangfire.Logging classes.
