### PR TITLE
ASP.NET Core & Hangfire.AspNetCore Doc Improvements

### DIFF
--- a/configuration/using-dashboard.rst
+++ b/configuration/using-dashboard.rst
@@ -9,7 +9,7 @@ Hangfire Dashboard is a place where you could find all the information about you
 Adding Dashboard (OWIN)
 -----------------
 
-.. admonition:: Additional package required for `ASP.NET <getting-started/aspnet-applications.rst>`_ and `ASP.NET Core <getting-started/aspnet-core-applications.rst>`_
+.. admonition:: Additional package required for ASP.NET + IIS
    :class: note
 
    Before moving to the next steps, ensure you have `Microsoft.Owin.Host.SystemWeb <https://www.nuget.org/packages/Microsoft.Owin.Host.SystemWeb/>`_ package installed, otherwise you'll have different strange problems with the Dashboard.

--- a/configuration/using-dashboard.rst
+++ b/configuration/using-dashboard.rst
@@ -6,10 +6,10 @@ Hangfire Dashboard is a place where you could find all the information about you
 .. contents::
    :local:
 
-Adding Dashboard
+Adding Dashboard (OWIN)
 -----------------
 
-.. admonition:: Additional package required for ASP.NET + IIS
+.. admonition:: Additional package required for `ASP.NET <getting-started/aspnet-applications.rst>`_ and `ASP.NET Core <getting-started/aspnet-core-applications.rst>`_
    :class: note
 
    Before moving to the next steps, ensure you have `Microsoft.Owin.Host.SystemWeb <https://www.nuget.org/packages/Microsoft.Owin.Host.SystemWeb/>`_ package installed, otherwise you'll have different strange problems with the Dashboard.

--- a/getting-started/aspnet-core-applications.rst
+++ b/getting-started/aspnet-core-applications.rst
@@ -138,6 +138,24 @@ After registering Hangfire types, you can now choose features you need to add to
        });
    }
 
+Starting with ``Hangfire.AspNetCore 1.7.8``, Hangfire officially supports ASP.NET Core 3.0 endpoint routing. When using ``RequireAuthorization`` with ``MapHangfireDashboard`` be cautious that only local access is allowed by default.
+
+.. code-block:: csharp
+   :emphasize-lines: 6,9
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        app.UseRouting();
+        app.UseAuthorization();
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapControllers();
+            endpoints.MapHangfireDashboard();
+        });
+    }
+    
+    
+
 Running Application
 --------------------
 


### PR DESCRIPTION
* Added details about endpoint routing
  * Also added note to documentation for HangfireIO/Hangfire#1593 when using `RequireAuthorization` with `Endpoint Routing`
* Making the `using dashboard` page slightly less confusing