### PR TITLE
Update aspnet-core-applications.rst

### DIFF
--- a/getting-started/aspnet-core-applications.rst
+++ b/getting-started/aspnet-core-applications.rst
@@ -103,6 +103,7 @@ Dependency Injection is one of the primary techniques introduced in ASP.NET Core
            }));
 
        // Add the processing server as IHostedService
+       // Note: Not available/required for netcoreapp31, net50 and so on
        services.AddHangfireServer();
 
        // Add framework services. 


### PR DESCRIPTION
Makes it clear that `.AddHangfireServer` isn't a thing anymore on net50 for instance.

I got confused, and still am a bit confused, but I guess the hosted service is registered elsewhere from 3.1 onwards?